### PR TITLE
Add: wrappers for autograder with zstd compression

### DIFF
--- a/wrappers/.gitignore
+++ b/wrappers/.gitignore
@@ -1,0 +1,3 @@
+/autograder.zip
+/pat
+/token

--- a/wrappers/build
+++ b/wrappers/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+# put pat in pat and token in token
+rm -f ./autograder.zip
+zip autograder.zip setup.sh run_autograder first-stage pat token start end

--- a/wrappers/end
+++ b/wrappers/end
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import requests
+import uuid
+import sys
+from datetime import datetime
+
+with open('uuid', 'r') as file:
+    id = uuid.UUID(file.read())
+with open('source/token', 'r') as file:
+    token = file.read().rstrip()
+with open('error.log', 'r') as file:
+    error = file.read().rstrip()
+headers = {'Authorization': "Bearer " + token}
+start = f"https://duckduckwhale.ucsd.edu/api/v1/<course>/<hw>/run/{id}/end"
+params = {'exit_status': int(sys.argv[1])}
+response = requests.post(start, params=params, headers=headers, data=error)
+if not response.ok:
+    print(f"[{datetime.now()}] Error: failed to send end request to observability backend")
+    print(f"[{datetime.now()}] Code: {response.status_code}")
+    print(f"[{datetime.now()}] Content: {response.content.decode('utf-8')}")

--- a/wrappers/first-stage
+++ b/wrappers/first-stage
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+repo="<repo>"
+org="<org>"
+ls source > /dev/null
+git --version > /dev/null
+git clone --quiet https://$(cat source/pat)@github.com/"$org"/"$repo".git > /dev/null
+rm source/pat
+rm -rf "$repo"/.git
+
+# install requirements here in case there are updates to the autograder library
+pip3 install --upgrade pip wheel
+pip3 install --force-reinstall -r "$repo"/requirements.txt
+
+python3 "$repo"/grade.py

--- a/wrappers/requirements.txt
+++ b/wrappers/requirements.txt
@@ -1,0 +1,1 @@
+tritongrader @ git+https://github.com/tritongrader/tritongrader@<hw>

--- a/wrappers/run_autograder
+++ b/wrappers/run_autograder
@@ -1,0 +1,7 @@
+#!/bin/sh
+source/start
+chmod +x source/first-stage
+mkfifo error-pipe
+tee -a error.log < error-pipe >&2 &
+source/first-stage 2> error-pipe
+source/end $?

--- a/wrappers/setup.sh
+++ b/wrappers/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+apt update
+apt upgrade -y
+# TODO add any extra dependencies of your autograder here
+apt install -y python3-zstd build-essential
+# TODO perform any other setup, if necessary

--- a/wrappers/start
+++ b/wrappers/start
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import requests
+import uuid
+import zstd
+from datetime import datetime
+
+id = uuid.uuid4()
+
+print(f"[{datetime.now()}] UUID: {id}")
+with open("uuid", "w") as file:
+    file.write(id.hex)
+with open("source/token", "r") as file:
+    token = file.read().rstrip()
+with open("/autograder/submission_metadata.json", "rb") as file:
+    metadata = zstd.ZSTD_compress(file.read())
+start = f"https://duckduckwhale.ucsd.edu/api/v1/<course>/<hw>/run/{id}/start"
+headers = {
+    "Authorization": "Bearer " + token,
+    "Content-Type": "application/json",
+    "Content-Encoding": "zstd"
+}
+response = requests.post(start, headers=headers, data=metadata)
+if not response.ok:
+    print(f"[{datetime.now()}] Error: failed to send start request to observability backend")
+    print(f"[{datetime.now()}] Code: {response.status_code}")
+    print(f"[{datetime.now()}] Content: {response.content.decode('utf-8')}")


### PR DESCRIPTION
We should also sort out `tests` -> `examples` at some point so the wrappers can live at the same location as the example grading script to allow any TA to build an autograder repo by copying a single directory.